### PR TITLE
Travis Kinetic fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,20 +6,16 @@ env:
   global:
     - UPSTREAM_WORKSPACE=https://raw.githubusercontent.com/kuka-isir/rtt_lwr/rtt_lwr-2.0/lwr_utils/config/rtt_lwr-full.rosinstall
     - ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
-    - NOT_TEST_BUILD='true'
-    - NOT_TEST_INSTALL='true'
+    - BEFORE_SCRIPT="source <(curl -s https://raw.githubusercontent.com/ahoarau/rtt_ros_integration-build/master/get_latest_rtt_ros_integration.sh)"
+    - ADDITIONAL_DEBS="curl"
+    
   matrix:
     - ROS_DISTRO="indigo"
     - ROS_DISTRO="jade"
-    - ROS_DISTRO="kinetic"
-
-matrix:
-  allow_failures:
-    - env: ROS_DISTRO="kinetic"
+    - ROS_DISTRO="kinetic" CATKIN_PARALLEL_JOBS="-p6 --cmake-args -DCMAKE_CXX_FLAGS=-std=c++11 --" ADDITIONAL_DEBS="curl libgazebo7-dev"
 
 install:
-  - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
+  - git clone https://github.com/ipa-mdl/industrial_ci -b fix/install-space .ci_config
 script:
   - source .ci_config/travis.sh
-
 


### PR DESCRIPTION
As rtt and rtt_ros are not released to kinetic yet, let's use the ones from the automated build repos : 

https://github.com/ahoarau/orocos_toolchain-build
https://github.com/ahoarau/rtt_ros_integration-build